### PR TITLE
Add Content-Type header to Proxy-Aggregator-Body

### DIFF
--- a/curryproxy/responses/response_base.py
+++ b/curryproxy/responses/response_base.py
@@ -75,6 +75,7 @@ class ResponseBase(object):
             results.append(result)
 
         self._response.body = json.dumps(results)
+        self._response.content_type = 'application/json'
 
     def _fix_headers(self):
         """Adjusts the Content-Encoding and Date headers if needed."""

--- a/curryproxy/tests/responses/response_base/ResponseBase/test__aggregate_response_bodies.py
+++ b/curryproxy/tests/responses/response_base/ResponseBase/test__aggregate_response_bodies.py
@@ -81,6 +81,10 @@ class Test_Aggregate_Response_Bodies(TestCase):
         response_base._aggregate_response_bodies()
 
         response = response_base.response.json
+        self.assertEqual(
+            'application/json',
+            response_base.response.content_type,
+        )
         self.assertEqual(3, len(response))
 
         self.assertEqual(url_1, response[0]['url'])


### PR DESCRIPTION
When the Proxy-Aggregator-Body header is set to response-metadata, add the Content-Type: application/json header to reflect that JSON is being returned. 