### PR TITLE
Fixes case sensitivity issue in endpoints route

### DIFF
--- a/curryproxy/routes/endpoints_route.py
+++ b/curryproxy/routes/endpoints_route.py
@@ -256,7 +256,9 @@ class EndpointsRoute(RouteBase):
             curry_param_dict = {}
             for ep_qs_pair in curry_param_list:
                 ep_id, query_string = ep_qs_pair.split(':')
-                curry_param_dict[ep_id] = urlparse.parse_qs(query_string)
+                curry_param_dict[ep_id.lower()] = urlparse.parse_qs(
+                    query_string
+                )
 
             if endpoint_id in curry_param_dict:
                 query_dict.update(curry_param_dict[endpoint_id])

--- a/curryproxy/tests/routes/endpoints_route/EndpointsRoute/test__resolve_query_string.py
+++ b/curryproxy/tests/routes/endpoints_route/EndpointsRoute/test__resolve_query_string.py
@@ -71,3 +71,14 @@ class Test_Resolve_Query_String(TestCase):
         )
 
         self.assertEquals(self.request_base_url + '?test=123', url)
+
+    def test_upper_case_curryproxy_parameters(self):
+        url = self.route._resolve_query_string(
+            (
+                self.request_base_url +
+                '?curryproxy=A:test=123'
+            ),
+            'a'
+        )
+
+        self.assertEquals(self.request_base_url + '?test=123', url)


### PR DESCRIPTION
Route-specific parameters with capitalized routes were not being generated properly upon route due to a mixed-case issue.