### PR TITLE
Add support for configVersion 2.

### DIFF
--- a/curryproxy/routes/route_factory.py
+++ b/curryproxy/routes/route_factory.py
@@ -21,10 +21,15 @@ Functions:
         rules defining return codes that may be bypassed.
 
 """
+import itertools
+import collections
+
 from curryproxy.errors import ConfigError
 from curryproxy.routes import EndpointsRoute
 from curryproxy.routes import ForwardingRoute
 from curryproxy.routes import StatusRoute
+
+CONF_LATEST_VERSION = 2
 
 
 def parse_ignore_rules(route_config):
@@ -54,6 +59,125 @@ def parse_ignore_rules(route_config):
                                   'than or equal to the stop value')
             ignore_errors.update(range(start, stop + 1))
     return ignore_errors
+
+
+def load(route_configs):
+    """Creates all routes defined in a configuration file.
+
+    This function is version-agnostic and will do any conversions necessary to
+    load old versions of the configuration format. It expects a data structure
+    read in from a configuration file with json.load, yaml.load, or similar.
+    """
+    # I'm not sure how the route objects this returns get used by the program;
+    # would it be useful/desirable to return a (statusroutes, forwards,
+    # endpoints) tuple instead?
+    return list(_load(_convert(route_configs)))
+
+
+def _load(route_configs):
+    """Generates all routes in a configuration file.
+
+    This function creates Route objects based on the most recent config file
+    format, i.e. it expects _convert to already have been called.
+    """
+    assert route_configs['configVersion'] == CONF_LATEST_VERSION
+
+    for s in route_configs.get('status', []):
+        yield StatusRoute(s)
+
+    for src, dest in route_configs.get('forwards', {}).items():
+        yield ForwardingRoute(src, dest)
+
+    for d in route_configs.get('routes', {}):
+        # Config v2 almost but doesn't quite match the EndpointsRoute
+        # constructor, so a bit of massaging is needed here...
+        d = d.copy()
+
+        # Convert error ranges into discrete lists.
+        ignore = []
+        for e in d['ignore_errors']:
+            e = str(e)
+            r = e.split("-")
+            start, end = int(r[0]), int(r[-1])
+            ignore.extend(range(start, end+1))
+        d['ignore_errors'] = ignore
+
+        # Accept singular url_pattern or plural url_patterns.
+        patterns = d.get('url_patterns', [])
+        if 'url_pattern' in d:
+            patterns.append(d.pop('url_pattern'))
+        d['url_patterns'] = patterns
+
+        yield EndpointsRoute(**d)
+
+
+def _convert(route_configs):
+    """Update old configuration data structure versions.
+
+    Returns a new data structure of the current version.
+
+    Should this be public?"""
+    # Convert from each version to the next version and repeat until reaching
+    # the latest. This makes it so we don't have to re-write the conversion
+    # code for all versions any time the configuration format changes; we only
+    # need to add a new function for the immediate prior version.
+
+    # First figure out what version we're working with.
+    try:
+        version = route_configs['configVersion']
+    except (TypeError):
+        # Version 1 had no specifier, but we can identify it anyway because its
+        # root node was not a dict.
+        version = 1
+    except (KeyError):
+        # If configVersion isn't provided, complain. Ideally this should
+        # autodetect in future.
+        raise ConfigError("configVersion format identifier missing.")
+
+    # Get the conversion functions between `version` and the current one, then
+    # call them sequentially. This relies on them all being named
+    # `_convert_v(number)`
+    converters = [globals()["_convert_v{}".format(i)]
+                  for i in range(version, CONF_LATEST_VERSION)]
+    for nextver in converters:
+        route_configs = nextver(route_configs)
+    return route_configs
+
+
+def _convert_v1(route_configs):
+    """Convert a v1 configuration data structure to v2."""
+
+    # Config version 1 was a top level list containing dicts that had a
+    # type marker. It was the only version without a version specifier.
+    newconf = dict()
+    newconf['configVersion'] = 2
+
+    # Status routes require no changes other than being moved to the top level.
+    # This will accept (and concatenate) multiple status-route dicts in the
+    # source, although it doesn't look like that was ever intended.
+    statusroutes = [d['status'] for d
+                    in route_configs
+                    if 'status' in d]
+    newconf['status'] = list(itertools.chain.from_iterable(statusroutes))
+
+    # Forwards were changed from key-value pairs mixed in with other stuff to a
+    # flat dict.
+    newconf['forwards'] = {d['route']: d['forwarding_url']
+                           for d in route_configs
+                           if 'forwarding_url' in d}
+
+    # Endpoint routes had one key renamed to match the EPR constructor, and the
+    # endpoints subdict was changed from a list of key-value dicts to a flat
+    # dict (which also matches the constructor). It's cleaner here to build the
+    # list first and modify it afterward.
+    newconf['routes'] = [d for d in route_configs
+                         if 'endpoints' in d]
+
+    for ep in newconf['routes']:
+        ep['url_patterns'] = [ep.pop('route')]
+        ep['endpoints'] = {ep['id']: ep['url'] for ep in ep['endpoints']}
+
+    return newconf
 
 
 def parse_dict(route_config):

--- a/etc/routes.sample.yaml
+++ b/etc/routes.sample.yaml
@@ -1,0 +1,15 @@
+configVersion: 2
+status:
+  - https://api.example.com/status
+forwards:
+  https://api.example.com/v1.0/: https://1.api.example.com/v1.0/
+routes:
+  - url_pattern: https://api.example.com/{Endpoint_IDs}/v2.0/
+    endpoints:
+      "1": https://1.api.example.com/v2.0
+      "2": https://2.api.example.com/v2.0
+    ignore_errors:
+      - 500
+      - 502-599
+    priority_errors:
+      - 401

--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -1,3 +1,4 @@
 grequests==0.2.0
 requests==2.2.1
 webob==1.2.3
+pyyaml>=3.11


### PR DESCRIPTION
Version 2 is somewhat flatter, noticeably cleaner, and allows for both
yaml and json input files.

I've been talking with Bryan about this over the last few days. For an idea of why it's useful, compare the readability of the [old sample config](https://github.com/rackerlabs/curryproxy/blob/master/etc/routes.sample.json) to the [new one](https://github.com/andrew-vant/curryproxy/blob/config_v2/etc/routes.sample.yaml). Probably shouldn't merge this as-is; I haven't updated tests, etc.

This replaces basically everything in route_factory.py; I didn't remove the parse functions (yet) because it made the diff difficult to read, but nothing references them anymore.
