### PR TITLE
CBU-1439 - Implement ElasticAPM in Curry

### DIFF
--- a/src/curryproxy/helpers.py
+++ b/src/curryproxy/helpers.py
@@ -46,6 +46,16 @@ from curryproxy.errors import ConfigError
 ENVIRON_REQUEST_UUID_KEY = 'curryproxy.request_uuid'
 LOGGING_LEVEL_DEBUG = 10
 
+# For elasticapm, we need to instantiate the client object and pass it around
+# as needed to begin and end transactions. Some functionality requires calling
+# methods of elasticapm directly, so we make both the base module and the
+# client object available to import from curryproxy.helpers
+try:
+    import elasticapm
+    apm = elasticapm.Client()
+except ImportError:
+    elasticapm, apm = None, None
+
 
 class ReprString(str):
     """A str subclass overriding the __repr__ function."""

--- a/src/curryproxy/server.py
+++ b/src/curryproxy/server.py
@@ -94,6 +94,8 @@ class CurryProxy(object):
                 specified by PEP 333.
 
         """
+        if helpers.apm:
+            helpers.apm.begin_transaction('proxy_request')
         request = Request(environ)
         response = None
 
@@ -109,6 +111,11 @@ class CurryProxy(object):
             response.status = 403
             response.body = json.dumps(str(request_error)).encode()
 
+        if helpers.apm:
+            helpers.apm.end_transaction(
+                name=f'{request.method.upper()} {request.path}',
+                result=response.status
+            )
         start_response(response.status, response.headerlist)
         return [response.body]
 

--- a/src/curryproxy/wsgi.py
+++ b/src/curryproxy/wsgi.py
@@ -8,5 +8,8 @@
 # chroot?
 
 from curryproxy import CurryProxy
+from curryproxy.helpers import elasticapm
 
 app = CurryProxy()
+if elasticapm:
+    elasticapm.instrument()


### PR DESCRIPTION
Curry does not utilize an OOB supported WSGI framework for automatic
instrumentation. That said, it is required to manually begin and end
transactions. To start with, I have done this in the simplest way I
could find possible. In the near future, we may want to try adding
more spans to the traces collected as well as additional context
information to the transactions, to get more use out of the agent.

Unfortunately, a lot of trace detail NewRelic was able to gather
automatically to report on will not be available at this time.